### PR TITLE
docs: Add in Joggr (docs platform for software devs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [Vizy](https://verbb.io/craft-plugins/vizy/features)
 - [Friday](https://friday.app)
 - [Eververse](https://www.eververse.ai/)
+- [Joggr](https://joggr.io)


### PR DESCRIPTION
Add in https://joggr.io, docs platform for software devs. 

Full disclosure I'm a co-founder 😄, we ❤️ TipTap and its core to our business!