### PR TITLE
update(flowbite): add wysiwyg editor resource built with tailwind css

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 ## Demos
 - [tiptap-markdown-demo](https://github.com/justinmoon/tiptap-markdown-demo) by [@justinmoon](https://github.com/justinmoon)
 - [umo-editor-playground](https://demo.umodoc.com/editor?lang=en-US&theme=light) by [@umodoc](https://github.com/umodoc)
+- [tailwind-css-wysiwyg-editor](https://flowbite.com/docs/plugins/wysiwyg/) by [@zoltanszogyenyi](https://github.com/zoltanszogyenyi)
 
 ## Vue.js
 - [tiptap-custom-link-vue-router](https://github.com/worldpwn/tiptap-custom-link-vue-router) by [@worldpwn](https://github.com/worldpwn)
@@ -84,3 +85,4 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [Eververse](https://www.eververse.ai/)
 - [Superthread](https://www.superthread.com)
 - [Joggr](https://joggr.io)
+- [Flowbite](https://flowbite.com)


### PR DESCRIPTION
Hey guys,

We've built an open-source wrapper/demo with Tailwind CSS using Tip Tap for Flowbite:

https://flowbite.com/docs/plugins/wysiwyg/

I think it's worth adding it here :)

Cheers,
Zoltan