### PR TITLE
Add Tiptap editor template

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [Text Diagram by Halo - Provides support for text drawing (Mermaid & PlantUML)](https://github.com/halo-sigs/plugin-text-diagram)
 - [fylepad - a notepad with powerful rich-text editing based on Nuxt3 and Tiptap.](https://github.com/imrofayel/fylepad) by [@imrofayel](https://github.com/imrofayel/)
 - [Maily](https://maily.to/) by [@arikchakma](https://github.com/arikchakma)
+- [Tiptap editor template](https://github.com/phyohtetarkar/tiptap-block-editor) by [@phyohtetarkar](https://github.com/phyohtetarkar)
 
 ## Who’s using Tiptap?
 - [Gamma](https://gamma.app/#recent)


### PR DESCRIPTION
Notion style AI-powered block editor build with [Tiptap](https://tiptap.dev/) + [Vercel AI SDK](https://sdk.vercel.ai/) + [Shadcn](https://ui.shadcn.com/) + [Tailwindcss](https://tailwindcss.com/).

- [Demo](https://phyohtetarkar.github.io/tiptap-block-editor/)