### PR TITLE
Add tiptap-extension-pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [tiptap-extension-global-drag-handle](https://github.com/NiclasDev63/tiptap-extension-global-drag-handle) by [@NiclasDev63](https://github.com/NiclasDev63)
 - [tiptap-velt-comments](https://www.npmjs.com/package/@veltdev/tiptap-velt-comments) by [@velt-js](https://github.com/velt-js)
 - [tiptap-extension-code-block-shiki](https://github.com/aolyang/tiptap-contentful/tree/main/packages/tiptap-extension-code-block-shiki) by [@aolyang](https://github.com/aolyang)
+- [tiptap-extension-pagination](https://github.com/hugs7/tiptap-extension-pagination) by [@hugs7](https://github.com/hugs7)
 
 ## Demos
 - [tiptap-markdown-demo](https://github.com/justinmoon/tiptap-markdown-demo) by [@justinmoon](https://github.com/justinmoon)


### PR DESCRIPTION
Add the TipTap page extension that adds page-related nodes to TipTap, allowing for more document-like layouts.