### PR TITLE
Add Gramax to Open Source Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [fylepad - a notepad with powerful rich-text editing based on Nuxt3 and Tiptap.](https://github.com/imrofayel/fylepad) by [@imrofayel](https://github.com/imrofayel/)
 - [Maily](https://maily.to/) by [@arikchakma](https://github.com/arikchakma)
 - [Tiptap editor template](https://github.com/phyohtetarkar/tiptap-block-editor) by [@phyohtetarkar](https://github.com/phyohtetarkar)
+- [Gramax - Create, edit, and publish Git-driven documentation sites using Markdown and a visual editor.](https://github.com/Gram-ax/gramax)
 
 ## Who’s using Tiptap?
 - [Gamma](https://gamma.app/#recent)


### PR DESCRIPTION
Gramax is a free, open-source application for creating, editing, and publishing documentation as code.
You could use Gramax if you want to self-host your documentation and seamlessly work with Markdown files and Git commands through a great visual editor based on Tiptap.

- [Website](https://gram.ax/)
- [GitHub](https://github.com/Gram-ax/gramax)