### PR TITLE
Add Yiitap editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [vuetify-pro-tiptap](https://github.com/yikoyu/vuetify-pro-tiptap) by [@yikoyu](https://github.com/yikoyu)
 - [umo-editor](https://github.com/umodoc/editor) by [@umodoc](https://github.com/umodoc)
 - [fylepad](https://github.com/imrofayel/fylepad) by [@imrofayel](https://github.com/imrofayel/)
+- [Yiitap](https://github.com/pileax-ai/yiitap) by [@pileax-ai](https://github.com/pileax-ai)
 
 ## Angular
 - [ngx-tiptap](https://github.com/sibiraj-s/ngx-tiptap) by [@sibiraj-s](https://github.com/sibiraj-s)
@@ -85,6 +86,7 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [fylepad - a notepad with powerful rich-text editing based on Nuxt3 and Tiptap.](https://github.com/imrofayel/fylepad) by [@imrofayel](https://github.com/imrofayel/)
 - [Maily](https://maily.to/) by [@arikchakma](https://github.com/arikchakma)
 - [Tiptap editor template](https://github.com/phyohtetarkar/tiptap-block-editor) by [@phyohtetarkar](https://github.com/phyohtetarkar)
+- [Yiitap - AI powered, Notion-style WYSIWYG rich-text editor, built on top of Tiptap](https://github.com/pileax-ai/yiitap) by [@pileax-ai](https://github.com/pileax-ai)
 
 ## Who’s using Tiptap?
 - [Gamma](https://gamma.app/#recent)


### PR DESCRIPTION
Yiitap is an AI powered, Notion-style WYSIWYG rich-text block-based editor, built on top of [tiptap](https://tiptap.dev/).🔥