### PR TITLE
Add Utopia Map without reordering existing entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,8 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [Velt](https://velt.dev)
 - [Flowbite](https://flowbite.com)
 - [PentestPad](https://pentestpad.com)
+<<<<<<< HEAD
 - [Fynk] (https://fynk.com)
+=======
+>>>>>>> ca7ebef (docs: add Utopia Map to awesome-tiptap list)
 - [TaleForge](https://www.tale-forge.com/)

--- a/README.md
+++ b/README.md
@@ -109,8 +109,5 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [Velt](https://velt.dev)
 - [Flowbite](https://flowbite.com)
 - [PentestPad](https://pentestpad.com)
-<<<<<<< HEAD
 - [Fynk] (https://fynk.com)
-=======
->>>>>>> ca7ebef (docs: add Utopia Map to awesome-tiptap list)
 - [TaleForge](https://www.tale-forge.com/)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 - [Maily](https://maily.to/) by [@arikchakma](https://github.com/arikchakma)
 - [Tiptap editor template](https://github.com/phyohtetarkar/tiptap-block-editor) by [@phyohtetarkar](https://github.com/phyohtetarkar)
 - [Yiitap - AI powered, Notion-style WYSIWYG rich-text editor](https://github.com/pileax-ai/yiitap) by [@pileax-ai](https://github.com/pileax-ai)
+- [Utopia Map - Collaborative map-based app for real-life networking and decentralized coordination](https://github.com/utopia-os/utopia-map)
 
 ## Who’s using Tiptap?
 - [Gamma](https://gamma.app/#recent)


### PR DESCRIPTION
This PR adds the Utopia Map entry to the Open source projects using Tiptap section and leaves the existing entry order unchanged.