### PR TITLE
Clean up README entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,57 @@
 # Awesome Tiptap
 
-A headless, framework-agnostic and extendable rich text editor, based on [ProseMirror](https://github.com/ProseMirror/prosemirror).
+A headless, framework-agnostic, and extensible rich text editor based on [ProseMirror](https://github.com/ProseMirror/prosemirror).
 
 [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/ueberdosis)
 
 ## Community extensions
 
-- [Official list of community extensions](https://github.com/ueberdosis/tiptap/issues/819)
-- [tiptap-languagetool](https://github.com/sereneinserenade/tiptap-languagetool) by [@sereneinserenade](https://github.com/sereneinserenade)
-- [tiptap-comment-extension](https://github.com/sereneinserenade/tiptap-comment-extension) by [@sereneinserenade](https://github.com/sereneinserenade)
-- [tiptap-search-and-replace](https://github.com/sereneinserenade/tiptap-search-n-replace-demo) by [@sereneinserenade](https://github.com/sereneinserenade)
-- [tiptap-extension-video](https://github.com/sereneinserenade/tiptap-extension-video) by [@sereneinserenade](https://github.com/sereneinserenade)
-- [tiptap-snippets-extension](https://github.com/sereneinserenade/tiptap-snippets-extension) by [@sereneinserenade](https://github.com/sereneinserenade)
-- [tiptap-media-resize](https://github.com/sereneinserenade/tiptap-media-resize) by [@sereneinserenade](https://github.com/sereneinserenade)
-- [tiptap-text-direction](https://github.com/amirhhashemi/tiptap-text-direction) by [@amirhhashemi](https://github.com/amirhhashemi)
-- [tiptap-comments](https://www.npmjs.com/package/@rcode-link/tiptap-comments) by [@radans](https://github.com/radans)
-- [tiptap-drawio-extension](https://github.com/radans/tiptap-drawio-extension) by [@radans](https://github.com/radans)
-- [tiptap-extension-office-paste](https://github.com/Intevation/tiptap-extension-office-paste) by [@Intevation](https://github.com/Intevation)
-- [tiptap-extension-upload-image](https://github.com/carlosvaldesweb/tiptap-extension-upload-image) by [@carlosvaldesweb](https://github.com/carlosvaldesweb)
-- [tiptap-footnotes](https://github.com/buttondown/tiptap-footnotes) by [@buttondown](https://github.com/buttondown)
-- [tiptap-extension-figma](https://github.com/haydenbleasel/tiptap-extension-figma) by [@haydenbleasel](https://github.com/haydenbleasel)
-- [tiptap-extension-jira](https://github.com/haydenbleasel/tiptap-extension-jira) by [@haydenbleasel](https://github.com/haydenbleasel)
-- [tiptap-slash-command](https://github.com/harshtalks/tiptap-plugins/tree/main/packages/slash-tiptap) by [@harshtalks](https://github.com/harshtalks)
-- [tiptap-image-resize-and-alignment](https://github.com/harshtalks/tiptap-plugins/tree/main/packages/image-tiptap) by [@harshtalks](https://github.com/harshtalks)
-- [tiptap-extension-iframely](https://github.com/haydenbleasel/tiptap-extension-iframely) by [@haydenbleasel](https://github.com/haydenbleasel)
-- [tiptap-extension-global-drag-handle](https://github.com/NiclasDev63/tiptap-extension-global-drag-handle) by [@NiclasDev63](https://github.com/NiclasDev63)
-- [tiptap-velt-comments](https://www.npmjs.com/package/@veltdev/tiptap-velt-comments) by [@velt-js](https://github.com/velt-js)
-- [tiptap-extension-code-block-shiki](https://github.com/aolyang/tiptap-contentful/tree/main/packages/tiptap-extension-code-block-shiki) by [@aolyang](https://github.com/aolyang)
-- [tiptap-extension-comment-collaboration](https://github.com/b310-digital/tiptap-extension-comment-collaboration) by [@b310-digital](https://github.com/b310-digital)
-- [tiptap-extension-figure](https://www.npmjs.com/package/@pentestpad/tiptap-extension-figure) by [@PentestPad](https://github.com/PentestPad) ([@Petar-CV](https://github.com/Petar-CV))
-- [tiptap-extension-pagination](https://github.com/hugs7/tiptap-extension-pagination) by [@hugs7](https://github.com/hugs7)
-- [tiptap-extension-multi-column](https://github.com/GYHHAHA/prosemirror-columns) by [@GYHHAHA](https://github.com/GYHHAHA)
+- [@tiptap-codeless/extension-code-block-pro](https://www.npmjs.com/package/@tiptap-codeless/extension-code-block-pro) by [@namelesserlx](https://github.com/namelesserlx)
 - [@tiptap-codeless/extension-drag-handle](https://www.npmjs.com/package/@tiptap-codeless/extension-drag-handle) by [@namelesserlx](https://github.com/namelesserlx)
 - [@tiptap-codeless/extension-file-upload](https://www.npmjs.com/package/@tiptap-codeless/extension-file-upload) by [@namelesserlx](https://github.com/namelesserlx)
-- [@tiptap-codeless/extension-code-block-pro](https://www.npmjs.com/package/@tiptap-codeless/extension-code-block-pro) by [@namelesserlx](https://github.com/namelesserlx)
+- [Official list of community extensions](https://github.com/ueberdosis/tiptap/issues/819)
+- [tiptap-comment-extension](https://github.com/sereneinserenade/tiptap-comment-extension) by [@sereneinserenade](https://github.com/sereneinserenade)
+- [tiptap-comments](https://www.npmjs.com/package/@rcode-link/tiptap-comments) by [@radans](https://github.com/radans)
+- [tiptap-drawio-extension](https://github.com/radans/tiptap-drawio-extension) by [@radans](https://github.com/radans)
+- [tiptap-extension-code-block-shiki](https://github.com/aolyang/tiptap-contentful/tree/main/packages/tiptap-extension-code-block-shiki) by [@aolyang](https://github.com/aolyang)
+- [tiptap-extension-comment-collaboration](https://github.com/b310-digital/tiptap-extension-comment-collaboration) by [@b310-digital](https://github.com/b310-digital)
+- [tiptap-extension-figma](https://github.com/haydenbleasel/tiptap-extension-figma) by [@haydenbleasel](https://github.com/haydenbleasel)
+- [tiptap-extension-figure](https://www.npmjs.com/package/@pentestpad/tiptap-extension-figure) by [@PentestPad](https://github.com/PentestPad) ([@Petar-CV](https://github.com/Petar-CV))
+- [tiptap-extension-global-drag-handle](https://github.com/NiclasDev63/tiptap-extension-global-drag-handle) by [@NiclasDev63](https://github.com/NiclasDev63)
+- [tiptap-extension-iframely](https://github.com/haydenbleasel/tiptap-extension-iframely) by [@haydenbleasel](https://github.com/haydenbleasel)
+- [tiptap-extension-jira](https://github.com/haydenbleasel/tiptap-extension-jira) by [@haydenbleasel](https://github.com/haydenbleasel)
+- [tiptap-extension-multi-column](https://github.com/GYHHAHA/prosemirror-columns) by [@GYHHAHA](https://github.com/GYHHAHA)
+- [tiptap-extension-office-paste](https://github.com/Intevation/tiptap-extension-office-paste) by [@Intevation](https://github.com/Intevation)
+- [tiptap-extension-pagination](https://github.com/hugs7/tiptap-extension-pagination) by [@hugs7](https://github.com/hugs7)
+- [tiptap-extension-upload-image](https://github.com/carlosvaldesweb/tiptap-extension-upload-image) by [@carlosvaldesweb](https://github.com/carlosvaldesweb)
+- [tiptap-extension-video](https://github.com/sereneinserenade/tiptap-extension-video) by [@sereneinserenade](https://github.com/sereneinserenade)
+- [tiptap-footnotes](https://github.com/buttondown/tiptap-footnotes) by [@buttondown](https://github.com/buttondown)
+- [tiptap-image-resize-and-alignment](https://github.com/harshtalks/tiptap-plugins/tree/main/packages/image-tiptap) by [@harshtalks](https://github.com/harshtalks)
+- [tiptap-languagetool](https://github.com/sereneinserenade/tiptap-languagetool) by [@sereneinserenade](https://github.com/sereneinserenade)
+- [tiptap-media-resize](https://github.com/sereneinserenade/tiptap-media-resize) by [@sereneinserenade](https://github.com/sereneinserenade)
+- [tiptap-search-and-replace](https://github.com/sereneinserenade/tiptap-search-n-replace-demo) by [@sereneinserenade](https://github.com/sereneinserenade)
+- [tiptap-slash-command](https://github.com/harshtalks/tiptap-plugins/tree/main/packages/slash-tiptap) by [@harshtalks](https://github.com/harshtalks)
+- [tiptap-snippets-extension](https://github.com/sereneinserenade/tiptap-snippets-extension) by [@sereneinserenade](https://github.com/sereneinserenade)
+- [tiptap-text-direction](https://github.com/amirhhashemi/tiptap-text-direction) by [@amirhhashemi](https://github.com/amirhhashemi)
+- [tiptap-velt-comments](https://www.npmjs.com/package/@veltdev/tiptap-velt-comments) by [@velt-js](https://github.com/velt-js)
 
 ## Demos
 
-- [tiptap-markdown-demo](https://github.com/justinmoon/tiptap-markdown-demo) by [@justinmoon](https://github.com/justinmoon)
-- [umo-editor-playground](https://demo.umodoc.com/editor?lang=en-US&theme=light) by [@umodoc](https://github.com/umodoc)
+- [Emoji picker](https://github.com/aolyang/tiptap-contentful/blob/main/example/src/components/toolbars/SelectEmojis.svelte) by [@aolyang](https://github.com/aolyang)
 - [google-docs-comments](https://documentation-app-demo.vercel.app) by [@velt-js](https://github.com/velt-js)
 - [tailwind-css-wysiwyg-editor](https://flowbite.com/docs/plugins/wysiwyg/) by [@zoltanszogyenyi](https://github.com/zoltanszogyenyi)
 - [tiptap-contentful svelte + tailwind](https://github.com/aolyang/tiptap-contentful) by [@aolyang](https://github.com/aolyang)
-- [emojis pickers](https://github.com/aolyang/tiptap-contentful/blob/main/example/src/components/toolbars/SelectEmojis.svelte) by [@aolyang](https://github.com/aolyang)
+- [tiptap-markdown-demo](https://github.com/justinmoon/tiptap-markdown-demo) by [@justinmoon](https://github.com/justinmoon)
 - [tiptap-multiple-choice-question-extension](https://github.com/Jianganchen/tiptap-extension-mcq) by [@Philip](https://github.com/Jianganchen)
+- [umo-editor-playground](https://demo.umodoc.com/editor?lang=en-US&theme=light) by [@umodoc](https://github.com/umodoc)
 
 ## Vue.js
 
-- [tiptap-custom-link-vue-router](https://github.com/worldpwn/tiptap-custom-link-vue-router) by [@worldpwn](https://github.com/worldpwn)
-- [vuetify-pro-tiptap](https://github.com/yikoyu/vuetify-pro-tiptap) by [@yikoyu](https://github.com/yikoyu)
-- [umo-editor](https://github.com/umodoc/editor) by [@umodoc](https://github.com/umodoc)
 - [fylepad](https://github.com/imrofayel/fylepad) by [@imrofayel](https://github.com/imrofayel/)
+- [tiptap-custom-link-vue-router](https://github.com/worldpwn/tiptap-custom-link-vue-router) by [@worldpwn](https://github.com/worldpwn)
+- [umo-editor](https://github.com/umodoc/editor) by [@umodoc](https://github.com/umodoc)
+- [vuetify-pro-tiptap](https://github.com/yikoyu/vuetify-pro-tiptap) by [@yikoyu](https://github.com/yikoyu)
 
 ## Angular
 
@@ -59,19 +59,19 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 
 ## Svelte
 
+- [Emoji picker](https://github.com/aolyang/tiptap-contentful/blob/main/example/src/components/toolbars/SelectEmojis.svelte) by [@aolyang](https://github.com/aolyang)
 - [svelte-tiptap](https://github.com/sibiraj-s/svelte-tiptap) by [@sibiraj-s](https://github.com/sibiraj-s)
 - [tiptap-contentful svelte + tailwind](https://github.com/aolyang/tiptap-contentful) by [@aolyang](https://github.com/aolyang)
-- [emojis pickers](https://github.com/aolyang/tiptap-contentful/blob/main/example/src/components/toolbars/SelectEmojis.svelte) by [@aolyang](https://github.com/aolyang)
 
 ## PHP
 
-- [Tiptap for PHP](https://github.com/ueberdosis/tiptap-php) by [@ueberdosis](https://github.com/ueberdosis) (official)
 - [Laravel Nova Tiptap Editor Field](https://github.com/manogi/nova-tiptap) by [@manogi](https://github.com/manogi)
+- [Tiptap for PHP](https://github.com/ueberdosis/tiptap-php) by [@ueberdosis](https://github.com/ueberdosis) (official)
 
 ## Python
 
-- [Python Library that converts Tiptap JSON](https://github.com/stckme/tiptapy) by [@stckme](https://github.com/stckme)
-- [django-tiptap : Use Tiptap Editor in django admin.](github.com/django-tiptap/django_tiptap) by [@solen0id](https://github.com/solen0id) and [@sereneinserenade](https://github.com/sereneinserenade))
+- [django-tiptap](https://github.com/django-tiptap/django_tiptap) by [@solen0id](https://github.com/solen0id) and [@sereneinserenade](https://github.com/sereneinserenade)
+- [Python library that converts Tiptap JSON](https://github.com/stckme/tiptapy) by [@stckme](https://github.com/stckme)
 
 ## Collaborative editing
 
@@ -79,54 +79,54 @@ A headless, framework-agnostic and extendable rich text editor, based on [ProseM
 
 ## Articles
 
-- [Migration from tiptap v.1 to tiptap v.2](https://dev.to/worldpwn/migration-from-tiptap-v1-to-tiptap-v2-1lh3)
+- [Migration from Tiptap v1 to Tiptap v2](https://dev.to/worldpwn/migration-from-tiptap-v1-to-tiptap-v2-1lh3)
 
 ## Open source projects using Tiptap
 
 - [Bible School LMS](https://github.com/ArVaViT/biblie-school) - Open-source LMS for Bible schools by [@ArVaViT](https://github.com/ArVaViT)
+- [fylepad](https://github.com/imrofayel/fylepad) - Notepad with rich text editing based on Nuxt 3 and Tiptap by [@imrofayel](https://github.com/imrofayel/)
 - [GitLab’s editor](https://gitlab.com/gitlab-org/gitlab/-/tree/master/app/assets/javascripts/content_editor)
-- [linked - journal app](https://github.com/lostdesign/linked) by [@lostdesign](https://github.com/lostdesign)
-- [Nextcloud Text - collaborative document editing using Markdown](https://github.com/nextcloud/text) by [@nextcloud](https://github.com/nextcloud)
-- [Notebag note-taking app](https://github.com/pretzelhands/notebag) by [@pretzelhands](https://github.com/pretzelhands)
-- [OpenSlides - A digital motion and assembly system](https://github.com/OpenSlides/OpenSlides)
-- [PlaceNoter - Chrome Extension, that replaces chrome's new tab with note-taking app.](https://github.com/sereneinserenade/placenoter/) by [@sereneinserenade](https://github.com/sereneinserenade)
-- [think - A collabrative web app build on tiptap, support markdown](https://github.com/fantasticit/think) by [@fantasticit](https://github.com/fantasticit)
-- [mui-tiptap - A Material UI (MUI) styled WYSIWYG rich text editor, using Tiptap](https://github.com/sjdemartini/mui-tiptap) by [@sjdemartini](https://github.com/sjdemartini)
-- [Novel](https://novel.sh/) by [@steventey](https://github.com/steven-tey)
-- [umo-editor - open-source document editor based on Vue3 and Tiptap](https://github.com/umodoc/editor) by [@umodoc](https://github.com/umodoc)
-- [Halo - Powerful and easy-to-use open source website building tool.](https://github.com/halo-dev/halo)
-- [Hyperlink Card by Halo - Convert normal hyperlinks to cards](https://github.com/halo-sigs/plugin-editor-hyperlink-card)
-- [Hyprnote - AI Notepad for Meetings](https://github.com/fastrepl/hyprnote)
-- [Markdown / HTML Content Block by Halo - Insert HTML and Markdown blocks into the editor](https://github.com/halo-sigs/plugin-hybrid-edit-block)
-- [KaTeX Block by Halo - Provides KaTeX support](https://github.com/halo-sigs/plugin-katex)
-- [Text Diagram by Halo - Provides support for text drawing (Mermaid & PlantUML)](https://github.com/halo-sigs/plugin-text-diagram)
-- [fylepad - a notepad with powerful rich-text editing based on Nuxt3 and Tiptap.](https://github.com/imrofayel/fylepad) by [@imrofayel](https://github.com/imrofayel/)
+- [Gramax](https://github.com/Gram-ax/gramax) - Git-driven documentation sites
+- [GroupWriter](https://github.com/b310-digital/groupwriter-frontend) - Collaborative writing app by [@b310-digital](https://github.com/b310-digital)
+- [Halo](https://github.com/halo-dev/halo) - Open-source website builder
+- [Hyperlink Card by Halo](https://github.com/halo-sigs/plugin-editor-hyperlink-card) - Converts hyperlinks to cards
+- [Hyprnote](https://github.com/fastrepl/hyprnote) - AI notepad for meetings
+- [Idea Forge](https://github.com/chenxiaoyao6228/idea-forge) - Notion-like collaborative document platform with AI capabilities by [@chenxiaoyao6228](https://github.com/chenxiaoyao6228)
+- [KaTeX Block by Halo](https://github.com/halo-sigs/plugin-katex) - Adds KaTeX support
+- [linked](https://github.com/lostdesign/linked) - Journal app by [@lostdesign](https://github.com/lostdesign)
+- [Maho](https://github.com/MahoCommerce/maho) - Ecommerce platform
 - [Maily](https://maily.to/) by [@arikchakma](https://github.com/arikchakma)
+- [Markdown / HTML Content Block by Halo](https://github.com/halo-sigs/plugin-hybrid-edit-block) - Inserts HTML and Markdown blocks into the editor
+- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap) - Material UI styled WYSIWYG rich text editor using Tiptap by [@sjdemartini](https://github.com/sjdemartini)
+- [Nextcloud Text](https://github.com/nextcloud/text) - Collaborative document editing using Markdown by [@nextcloud](https://github.com/nextcloud)
+- [Notebag](https://github.com/pretzelhands/notebag) - Note-taking app by [@pretzelhands](https://github.com/pretzelhands)
+- [Novel](https://novel.sh/) by [@steventey](https://github.com/steven-tey)
+- [OpenSlides](https://github.com/OpenSlides/OpenSlides) - Digital motion and assembly system
+- [PlaceNoter](https://github.com/sereneinserenade/placenoter/) - Chrome extension that replaces the new tab with a note-taking app by [@sereneinserenade](https://github.com/sereneinserenade)
+- [Text Diagram by Halo](https://github.com/halo-sigs/plugin-text-diagram) - Adds Mermaid and PlantUML diagram support
+- [think](https://github.com/fantasticit/think) - Collaborative web app built on Tiptap with Markdown support by [@fantasticit](https://github.com/fantasticit)
 - [Tiptap editor template](https://github.com/phyohtetarkar/tiptap-block-editor) by [@phyohtetarkar](https://github.com/phyohtetarkar)
-- [GroupWriter - Collaborative Writing App](https://github.com/b310-digital/groupwriter-frontend) by [@b310-digital](https://github.com/b310-digital)
-- [Gramax - Publish Git-driven documentation sites](https://github.com/Gram-ax/gramax)
-- [Maho ecommerce platform](https://github.com/MahoCommerce/maho)
-- [Idea Forge - Notion-like collaborative document platform with AI capabilities](https://github.com/chenxiaoyao6228/idea-forge) by [@chenxiaoyao6228](https://github.com/chenxiaoyao6228)
-- [Yiitap - AI powered, Notion-style WYSIWYG rich-text editor](https://github.com/pileax-ai/yiitap) by [@pileax-ai](https://github.com/pileax-ai)
-- [Utopia Map - Collaborative map-based app for real-life networking and decentralized coordination](https://github.com/utopia-os/utopia-map)
+- [umo-editor](https://github.com/umodoc/editor) - Open-source document editor based on Vue 3 and Tiptap by [@umodoc](https://github.com/umodoc)
+- [Utopia Map](https://github.com/utopia-os/utopia-map) - Collaborative map-based app for networking and coordination
+- [Yiitap](https://github.com/pileax-ai/yiitap) - AI-powered, Notion-style WYSIWYG rich text editor by [@pileax-ai](https://github.com/pileax-ai)
 
 ## Who’s using Tiptap?
 
-- [Gamma](https://gamma.app/#recent)
-- [mymind](https://mymind.com)
 - [DocIQ](https://www.dociq.io)
-- [Statamic](https://statamic.com)
-- [Letter](https://letter.so)
-- [Primo](https://primo.so)
-- [OnePile](https://onepile.app) by [@holtwick](https://github.com/holtwick)
-- [Storipress](https://storipress.com)
-- [Vizy](https://verbb.io/craft-plugins/vizy/features)
-- [Friday](https://friday.app)
 - [Eververse](https://www.eververse.ai/)
-- [Superthread](https://www.superthread.com)
-- [Joggr](https://joggr.io)
-- [Velt](https://velt.dev)
 - [Flowbite](https://flowbite.com)
+- [Friday](https://friday.app)
+- [Fynk](https://fynk.com)
+- [Gamma](https://gamma.app/#recent)
+- [Joggr](https://joggr.io)
+- [Letter](https://letter.so)
+- [mymind](https://mymind.com)
+- [OnePile](https://onepile.app) by [@holtwick](https://github.com/holtwick)
 - [PentestPad](https://pentestpad.com)
-- [Fynk] (https://fynk.com)
+- [Primo](https://primo.so)
+- [Statamic](https://statamic.com)
+- [Storipress](https://storipress.com)
+- [Superthread](https://www.superthread.com)
 - [TaleForge](https://www.tale-forge.com/)
+- [Velt](https://velt.dev)
+- [Vizy](https://verbb.io/craft-plugins/vizy/features)


### PR DESCRIPTION
## Summary

This updates `README.md` so the lists are easier to scan and follow the existing contribution style. It fixes Markdown formatting, list ordering, spelling, grammar, and overly broad product descriptions.

## Issues fixed

Unsorted entries were reordered alphabetically inside each section. For example, the `Who’s using Tiptap?` section now follows alphabetical order:

```md
- [DocIQ](https://www.dociq.io)
- [Eververse](https://www.eververse.ai/)
- [Flowbite](https://flowbite.com)
```

Malformed Markdown and broken links were corrected. For example:

```md
- [Fynk](https://fynk.com)
- [django-tiptap](https://github.com/django-tiptap/django_tiptap)
```

Project entries now keep only the project name in the link text, with the description outside the link and no trailing full stop:

```md
- [PlaceNoter](https://github.com/sereneinserenade/placenoter/) - Chrome extension that replaces the new tab with a note-taking app by [@sereneinserenade](https://github.com/sereneinserenade)
```

Spelling, grammar, and casing were cleaned up, including the Tiptap spelling in prose:

```md
- [Migration from Tiptap v1 to Tiptap v2](https://dev.to/worldpwn/migration-from-tiptap-v1-to-tiptap-v2-1lh3)
```

Marketing-style descriptions were shortened into direct descriptions. For example:

```md
- [Halo](https://github.com/halo-dev/halo) - Open-source website builder
```

## Verification

- Checked README list entries for alphabetical order
- Searched for malformed Markdown links and stale `TipTap` spelling
