### PR TITLE
Clean up README project descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 ## Open source projects using Tiptap
 
 - [Bible School LMS](https://github.com/ArVaViT/biblie-school) - Open-source LMS for Bible schools by [@ArVaViT](https://github.com/ArVaViT)
-- [fylepad](https://github.com/imrofayel/fylepad) - Notepad with rich text editing based on Nuxt 3 and Tiptap by [@imrofayel](https://github.com/imrofayel/)
+- [fylepad](https://github.com/imrofayel/fylepad) - Notepad with rich text editing based on Nuxt 3 by [@imrofayel](https://github.com/imrofayel/)
 - [GitLab’s editor](https://gitlab.com/gitlab-org/gitlab/-/tree/master/app/assets/javascripts/content_editor)
 - [Gramax](https://github.com/Gram-ax/gramax) - Git-driven documentation sites by [@Gram-ax](https://github.com/Gram-ax)
 - [GroupWriter](https://github.com/b310-digital/groupwriter-frontend) - Collaborative writing app by [@b310-digital](https://github.com/b310-digital)
@@ -97,16 +97,16 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [Maho](https://github.com/MahoCommerce/maho) - Ecommerce platform by [@MahoCommerce](https://github.com/MahoCommerce)
 - [Maily](https://maily.to/) by [@arikchakma](https://github.com/arikchakma)
 - [Markdown / HTML Content Block by Halo](https://github.com/halo-sigs/plugin-hybrid-edit-block) - Inserts HTML and Markdown blocks into the editor by [@halo-sigs](https://github.com/halo-sigs)
-- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap) - Material UI styled WYSIWYG rich text editor using Tiptap by [@sjdemartini](https://github.com/sjdemartini)
+- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap) - Material UI styled WYSIWYG rich text editor by [@sjdemartini](https://github.com/sjdemartini)
 - [Nextcloud Text](https://github.com/nextcloud/text) - Collaborative document editing using Markdown by [@nextcloud](https://github.com/nextcloud)
 - [Notebag](https://github.com/pretzelhands/notebag) - Note-taking app by [@pretzelhands](https://github.com/pretzelhands)
 - [Novel](https://novel.sh/) by [@steventey](https://github.com/steven-tey)
 - [OpenSlides](https://github.com/OpenSlides/OpenSlides) - Digital motion and assembly system by [@OpenSlides](https://github.com/OpenSlides)
 - [PlaceNoter](https://github.com/sereneinserenade/placenoter/) - Chrome extension that replaces the new tab with a note-taking app by [@sereneinserenade](https://github.com/sereneinserenade)
 - [Text Diagram by Halo](https://github.com/halo-sigs/plugin-text-diagram) - Adds Mermaid and PlantUML diagram support by [@halo-sigs](https://github.com/halo-sigs)
-- [think](https://github.com/fantasticit/think) - Collaborative web app built on Tiptap with Markdown support by [@fantasticit](https://github.com/fantasticit)
+- [think](https://github.com/fantasticit/think) - Collaborative web app with Markdown support by [@fantasticit](https://github.com/fantasticit)
 - [Tiptap editor template](https://github.com/phyohtetarkar/tiptap-block-editor) by [@phyohtetarkar](https://github.com/phyohtetarkar)
-- [umo-editor](https://github.com/umodoc/editor) - Open-source document editor based on Vue 3 and Tiptap by [@umodoc](https://github.com/umodoc)
+- [umo-editor](https://github.com/umodoc/editor) - Open-source document editor based on Vue 3 by [@umodoc](https://github.com/umodoc)
 - [Utopia Map](https://github.com/utopia-os/utopia-map) - Collaborative map-based app for networking and coordination by [@utopia-os](https://github.com/utopia-os)
 - [Yiitap](https://github.com/pileax-ai/yiitap) - AI-powered, Notion-style WYSIWYG rich text editor by [@pileax-ai](https://github.com/pileax-ai)
 


### PR DESCRIPTION
## Summary

This updates README project descriptions that redundantly mention Tiptap in the "Open source projects using Tiptap" section. Because the section already establishes that context, the descriptions now focus on what each project is.

## Issues fixed

- Removed redundant Tiptap wording from the fylepad description:

```diff
-- [fylepad](https://github.com/imrofayel/fylepad) - Notepad with rich text editing based on Nuxt 3 and Tiptap by [@imrofayel](https://github.com/imrofayel/)
+- [fylepad](https://github.com/imrofayel/fylepad) - Notepad with rich text editing based on Nuxt 3 by [@imrofayel](https://github.com/imrofayel/)
```

- Removed redundant Tiptap wording from the mui-tiptap description:

```diff
-- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap) - Material UI styled WYSIWYG rich text editor using Tiptap by [@sjdemartini](https://github.com/sjdemartini)
+- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap) - Material UI styled WYSIWYG rich text editor by [@sjdemartini](https://github.com/sjdemartini)
```

- Removed redundant Tiptap wording from the think description:

```diff
-- [think](https://github.com/fantasticit/think) - Collaborative web app built on Tiptap with Markdown support by [@fantasticit](https://github.com/fantasticit)
+- [think](https://github.com/fantasticit/think) - Collaborative web app with Markdown support by [@fantasticit](https://github.com/fantasticit)
```

- Removed redundant Tiptap wording from the umo-editor description:

```diff
-- [umo-editor](https://github.com/umodoc/editor) - Open-source document editor based on Vue 3 and Tiptap by [@umodoc](https://github.com/umodoc)
+- [umo-editor](https://github.com/umodoc/editor) - Open-source document editor based on Vue 3 by [@umodoc](https://github.com/umodoc)
```

## Verification

- Checked for `TipTap` casing issues
- Checked for redundant `using Tiptap`, `built on Tiptap`, and `based on ... Tiptap` wording
- Checked that multi-entry sections remain alphabetically sorted