### PR TITLE
Add Tiptap projects and articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [@tiptap-codeless/extension-code-block-pro](https://www.npmjs.com/package/@tiptap-codeless/extension-code-block-pro) by [@namelesserlx](https://github.com/namelesserlx)
 - [@tiptap-codeless/extension-drag-handle](https://www.npmjs.com/package/@tiptap-codeless/extension-drag-handle) by [@namelesserlx](https://github.com/namelesserlx)
 - [@tiptap-codeless/extension-file-upload](https://www.npmjs.com/package/@tiptap-codeless/extension-file-upload) by [@namelesserlx](https://github.com/namelesserlx)
+- [minimal-tiptap](https://github.com/Aslam97/minimal-tiptap) by [@Aslam97](https://github.com/Aslam97)
 - [Official list of community extensions](https://github.com/ueberdosis/tiptap/issues/819)
+- [shadcn-tiptap](https://github.com/NiazMorshed2007/shadcn-tiptap) by [@NiazMorshed2007](https://github.com/NiazMorshed2007)
 - [tiptap-comment-extension](https://github.com/sereneinserenade/tiptap-comment-extension) by [@sereneinserenade](https://github.com/sereneinserenade)
 - [tiptap-comments](https://www.npmjs.com/package/@rcode-link/tiptap-comments) by [@radans](https://github.com/radans)
 - [tiptap-drawio-extension](https://github.com/radans/tiptap-drawio-extension) by [@radans](https://github.com/radans)
@@ -29,6 +31,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [tiptap-footnotes](https://github.com/buttondown/tiptap-footnotes) by [@buttondown](https://github.com/buttondown)
 - [tiptap-image-resize-and-alignment](https://github.com/harshtalks/tiptap-plugins/tree/main/packages/image-tiptap) by [@harshtalks](https://github.com/harshtalks)
 - [tiptap-languagetool](https://github.com/sereneinserenade/tiptap-languagetool) by [@sereneinserenade](https://github.com/sereneinserenade)
+- [tiptap-markdown](https://github.com/aguingand/tiptap-markdown) by [@aguingand](https://github.com/aguingand)
 - [tiptap-media-resize](https://github.com/sereneinserenade/tiptap-media-resize) by [@sereneinserenade](https://github.com/sereneinserenade)
 - [tiptap-search-and-replace](https://github.com/sereneinserenade/tiptap-search-n-replace-demo) by [@sereneinserenade](https://github.com/sereneinserenade)
 - [tiptap-slash-command](https://github.com/harshtalks/tiptap-plugins/tree/main/packages/slash-tiptap) by [@harshtalks](https://github.com/harshtalks)
@@ -49,6 +52,8 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 ## Vue.js
 
 - [fylepad](https://github.com/imrofayel/fylepad) by [@imrofayel](https://github.com/imrofayel/)
+- [nuxt-tiptap-editor](https://github.com/modbender/nuxt-tiptap-editor) by [@modbender](https://github.com/modbender)
+- [tiptap-vuetify](https://github.com/777genius/tiptap-vuetify) by [@777genius](https://github.com/777genius)
 - [tiptap-custom-link-vue-router](https://github.com/worldpwn/tiptap-custom-link-vue-router) by [@worldpwn](https://github.com/worldpwn)
 - [umo-editor](https://github.com/umodoc/editor) by [@umodoc](https://github.com/umodoc)
 - [vuetify-pro-tiptap](https://github.com/yikoyu/vuetify-pro-tiptap) by [@yikoyu](https://github.com/yikoyu)
@@ -65,6 +70,8 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 
 ## PHP
 
+- [Filament Tiptap Editor](https://github.com/awcodes/filament-tiptap-editor) by [@awcodes](https://github.com/awcodes)
+- [laravel-tiptap](https://github.com/georgeboot/laravel-tiptap) by [@georgeboot](https://github.com/georgeboot)
 - [Laravel Nova Tiptap Editor Field](https://github.com/manogi/nova-tiptap) by [@manogi](https://github.com/manogi)
 - [Tiptap for PHP](https://github.com/ueberdosis/tiptap-php) by [@ueberdosis](https://github.com/ueberdosis) (official)
 
@@ -79,7 +86,17 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 
 ## Articles
 
+- [Best Text Editors For React](https://blog.logrocket.com/best-text-editors-react/)
+- [Creating a custom extension for Rich Text Editor using TipTap](https://www.websight.io/blog/2023/creating-a-custom-extension-for-rich-text-editor-using-tiptap.html)
+- [Easy collaborative text editing with Liveblocks Tiptap](https://liveblocks.io/blog/easy-collaborative-text-editing-with-liveblocks-tiptap)
+- [Effortless Rich Text Editing In React With @mantine/tiptap: A Comprehensive Guide](https://codingeasypeasy.com/blog/effortless-rich-text-editing-in-react-with-mantinetiptap-a-comprehensive-guide)
+- [How to quickly add a rich text editor to your Next.js project using TipTap](https://dev.to/joeskills/how-to-add-a-rich-text-editor-to-your-nextjs-project-using-tiptap-1fil)
+- [How to Use TipTap Editor with Vue 3](https://dev.to/jsandaruwan/how-to-use-tiptap-editor-with-vue-3-4n3l)
 - [Migration from Tiptap v1 to Tiptap v2](https://dev.to/worldpwn/migration-from-tiptap-v1-to-tiptap-v2-1lh3)
+- [Switching Rich Text Editors, Part 1: Picking Tiptap](https://www.ashbyhq.com/blog/engineering/tiptap-part-1)
+- [Tiptapでメールマガジン用のHTMLメールエディターを作った](https://tech.asoview.co.jp/entry/2024/12/08/090000)
+- [Top 5 rich-text React components](https://www.sanity.io/guides/top-5-rich-text-react-components)
+- [Using Tiptap Rich Text Editor with Livewire](https://sudorealm.com/blog/using-tiptap-rich-text-editor-with-livewire)
 
 ## Open source projects using Tiptap
 
@@ -103,6 +120,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [Maho](https://github.com/MahoCommerce/maho) - E-commerce platform by [@MahoCommerce](https://github.com/MahoCommerce)
 - [Maily](https://maily.to/) by [@arikchakma](https://github.com/arikchakma)
 - [Markdown / HTML Content Block by Halo](https://github.com/halo-sigs/plugin-hybrid-edit-block) - Inserts HTML and Markdown blocks into the editor by [@halo-sigs](https://github.com/halo-sigs)
+- [Mantine Tiptap](https://github.com/mantinedev/mantine/tree/master/packages/%40mantine/tiptap) - Tiptap-based rich text editor component for Mantine by [@mantinedev](https://github.com/mantinedev)
 - [mui-tiptap](https://github.com/sjdemartini/mui-tiptap) - Material UI-styled WYSIWYG rich text editor by [@sjdemartini](https://github.com/sjdemartini)
 - [Nextcloud Text](https://github.com/nextcloud/text) - Collaborative document editing using Markdown by [@nextcloud](https://github.com/nextcloud)
 - [Notebag](https://github.com/pretzelhands/notebag) - Note-taking app by [@pretzelhands](https://github.com/pretzelhands)
@@ -111,6 +129,8 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [OpenSlides](https://github.com/OpenSlides/OpenSlides) - Digital motion and assembly system by [@OpenSlides](https://github.com/OpenSlides)
 - [PlaceNoter](https://github.com/sereneinserenade/placenoter/) - Chrome extension that replaces the new tab with a note-taking app by [@sereneinserenade](https://github.com/sereneinserenade)
 - [Plane](https://github.com/makeplane/plane) - Open-source project management platform by [@makeplane](https://github.com/makeplane)
+- [reactjs-tiptap-editor](https://github.com/hunghg255/reactjs-tiptap-editor) - WYSIWYG rich text editor based on Tiptap and shadcn/ui by [@hunghg255](https://github.com/hunghg255)
+- [strapi-tiptap-editor](https://github.com/dasmikko/strapi-tiptap-editor) - Tiptap editor plugin for Strapi by [@dasmikko](https://github.com/dasmikko)
 - [Text Diagram by Halo](https://github.com/halo-sigs/plugin-text-diagram) - Adds Mermaid and PlantUML diagram support by [@halo-sigs](https://github.com/halo-sigs)
 - [think](https://github.com/fantasticit/think) - Collaborative web app with Markdown support by [@fantasticit](https://github.com/fantasticit)
 - [Tiptap editor template](https://github.com/phyohtetarkar/tiptap-block-editor) by [@phyohtetarkar](https://github.com/phyohtetarkar)


### PR DESCRIPTION
## Summary

Adds newly researched Tiptap resources to the README:

- 10 project/library entries across community extensions, framework categories, PHP, and open-source projects
- 10 article entries covering production migration, collaboration, framework integrations, and implementation guides

## Validation

- Ran `git diff --check`
- Checked for duplicate URLs; duplicates reported were pre-existing repeated category links, not the newly added URLs