### PR TITLE
Add docen

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [Activepieces](https://github.com/activepieces/activepieces) - Open-source AI automation platform by [@activepieces](https://github.com/activepieces)
 - [Bible School LMS](https://github.com/ArVaViT/biblie-school) - Open-source LMS for Bible schools by [@ArVaViT](https://github.com/ArVaViT)
 - [Cloudflare Agentic Inbox](https://github.com/cloudflare/agentic-inbox) - Self-hosted email client with an AI agent by [@cloudflare](https://github.com/cloudflare)
+- [docen](https://github.com/DemoMacro/docen) - Open-source WYSIWYG DOCX editor with a Fluent UI host, fixed-page pagination, and Office.js-style add-ins by [@DemoMacro](https://github.com/DemoMacro)
 - [Docmost](https://github.com/docmost/docmost) - Open-source collaborative wiki and documentation software by [@docmost](https://github.com/docmost)
 - [Doist Typist](https://github.com/Doist/typist) - Tiptap-based rich text editor powering Doist products by [@Doist](https://github.com/Doist)
 - [Dub](https://github.com/dubinc/dub) - Open-source link management platform by [@dubinc](https://github.com/dubinc)


### PR DESCRIPTION
Adds [docen](https://github.com/DemoMacro/docen) to the "Open source projects using Tiptap" section.

docen is a monorepo for DOCX editing and document conversion, built on Tiptap:

- `@docen/docx` — Tiptap DOCX editor and DOCX/HTML/Markdown converters
- `@docen/editor` — Fluent UI web-component editor (`<docen-document>`) with fixed-page pagination and an Office.js-style add-in system
- `@docen/vue` — Vue 3 adapter

Custom Tiptap extensions carry DOCX properties (shading, borders, indent, spacing, floating) for DOCX round-trip.

Entry placed alphabetically (between Cloudflare Agentic Inbox and Docmost).
