### PR TITLE
Add Trainual to "Who's using Tiptap?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [Storipress](https://storipress.com)
 - [Superthread](https://www.superthread.com)
 - [TaleForge](https://www.tale-forge.com/)
+- [Trainual](https://trainual.com)
 - [Velt](https://velt.dev)
 - [Vizy](https://verbb.io/craft-plugins/vizy/features)
 - [Wordware](https://www.wordware.ai)


### PR DESCRIPTION
Trainual (https://trainual.com) is a training and onboarding platform for small businesses. Our training content editor is built on Tiptap, with full collaboration, version history, and commenting built in, and we use several other Tiptap-based editors throughout the app. Added in alphabetical order.