### PR TITLE
Add @devslab/editor-ruler-tiptap to community extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 
 ## Community extensions
 
+- [@devslab/editor-ruler-tiptap](https://www.npmjs.com/package/@devslab/editor-ruler-tiptap) by [@devslab-kr](https://github.com/devslab-kr)
 - [@tiptap-codeless/extension-code-block-pro](https://www.npmjs.com/package/@tiptap-codeless/extension-code-block-pro) by [@namelesserlx](https://github.com/namelesserlx)
 - [@tiptap-codeless/extension-drag-handle](https://www.npmjs.com/package/@tiptap-codeless/extension-drag-handle) by [@namelesserlx](https://github.com/namelesserlx)
 - [@tiptap-codeless/extension-file-upload](https://www.npmjs.com/package/@tiptap-codeless/extension-file-upload) by [@namelesserlx](https://github.com/namelesserlx)


### PR DESCRIPTION
Adds [`@devslab/editor-ruler-tiptap`](https://www.npmjs.com/package/@devslab/editor-ruler-tiptap) (Apache-2.0) — a Word-like horizontal ruler extension: drag handles for left/right margins and first-line indent (hanging indent included), guide lines with snapping, cm/inch/px scales. Indentation is stored as node attributes and rendered as plain inline CSS; a whole drag is one undo step. Works with Tiptap v2/v3.

Live demo (Tiptap tab): https://devslab-kr.github.io/editor-ruler/
StackBlitz: https://stackblitz.com/github/devslab-kr/editor-ruler/tree/main/examples/tiptap

Inserted alphabetically at the top of the community extensions list.