### PR TITLE
Add BitFun to open source projects using Tiptap

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [Activepieces](https://github.com/activepieces/activepieces) - Open-source AI automation platform by [@activepieces](https://github.com/activepieces)
 - [api-doctor](https://github.com/qualtyco/api-doctor) - Open-source rules that catch common Tiptap mistakes in AI-generated Tiptap code by [@qualtyco](https://github.com/qualtyco)
 - [Bible School LMS](https://github.com/ArVaViT/biblie-school) - Open-source LMS for Bible schools by [@ArVaViT](https://github.com/ArVaViT)
+- [BitFun](https://github.com/GCWing/BitFun) - Cross-platform AI agent with a Tiptap-based Markdown editor and inline AI writing tools by [@GCWing](https://github.com/GCWing)
 - [Cloudflare Agentic Inbox](https://github.com/cloudflare/agentic-inbox) - Self-hosted email client with an AI agent by [@cloudflare](https://github.com/cloudflare)
 - [docen](https://github.com/DemoMacro/docen) - Open-source WYSIWYG DOCX editor with a Fluent UI host, fixed-page pagination, and Office.js-style add-ins by [@DemoMacro](https://github.com/DemoMacro)
 - [Docmost](https://github.com/docmost/docmost) - Open-source collaborative wiki and documentation software by [@docmost](https://github.com/docmost)


### PR DESCRIPTION
I help maintain BitFun. Its Markdown editor is built on Tiptap 3 with official extensions for links, tasks, details, and placeholders, plus custom extensions for Markdown tables, images, raw HTML, and inline AI previews.

This adds it to the Open source projects using Tiptap section in alphabetical order.