### PR TITLE
Add wordpaste to community extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A headless, framework-agnostic, and extensible rich text editor based on [ProseM
 - [tiptap-writetrack](https://www.npmjs.com/package/@writetrack/tiptap) by [@ammil-industries](https://github.com/ammil-industries)
 - [tiptap-marquee-selection](https://github.com/jeunecouy/tiptap-marquee-selection) by [@jeunecouy](https://github.com/jeunecouy)
 - [tiptap-model-language](https://www.npmjs.com/package/tiptap-model-language) by [@WexioHub](https://github.com/Wexiohub)
+- [wordpaste](https://github.com/smrifat1411/wordpaste) by [@smrifat1411](https://github.com/smrifat1411)
 
 ## Demos
 


### PR DESCRIPTION
Adds [wordpaste](https://github.com/smrifat1411/wordpaste) — a `transformPastedHTML` function for cleaning Microsoft Word clipboard HTML.

It plugs straight into `editorProps`, so there is no extension to write:

```js
import { transformPastedHTML } from 'wordpaste';

new Editor({
  extensions: [StarterKit],
  editorProps: { transformPastedHTML },
});
```

Two things it does that I could not find elsewhere:

- **Equations stay editable.** Word puts a rasterized picture *and* the real OMML on the clipboard. wordpaste converts the OMML to LaTeX and emits `@tiptap/extension-mathematics` markup, so a pasted equation is still an equation instead of a screenshot.
- **Lists come back as lists.** Word pastes list items as `<p>` tags with the number as literal text, so naive cleaning freezes "1." and "2." into the paragraph. wordpaste reads Word's own markers before discarding them and rebuilds `<ul>`/`<ol>` with nesting, the original sequence and `start`.

Zero dependencies, 3.5 kB gzipped, types included, MIT. Also works with ProseMirror, Lexical and plain `contenteditable`.

Live playground: https://smrifat1411.github.io/wordpaste/
